### PR TITLE
Reload shopping lists on back press

### DIFF
--- a/shopping_list/src/main/java/com/zizohanto/android/tobuy/shopping_list/presentation/shopping_list/ShoppingListViewModel.kt
+++ b/shopping_list/src/main/java/com/zizohanto/android/tobuy/shopping_list/presentation/shopping_list/ShoppingListViewModel.kt
@@ -21,7 +21,7 @@ class ShoppingListViewModel @Inject constructor(
 
     init {
         shoppingListStateMachine.processor.launchIn(viewModelScope)
-        processIntent(ShoppingListViewIntent.LoadShoppingLists)
+        loadShoppingLists()
     }
 
     override fun processIntent(intents: Flow<ShoppingListViewIntent>) {
@@ -38,7 +38,7 @@ class ShoppingListViewModel @Inject constructor(
         processIntent(ShoppingListViewIntent.CreateNewShoppingList)
     }
 
-    fun onRetry() {
+    fun loadShoppingLists() {
         processIntent(ShoppingListViewIntent.LoadShoppingLists)
     }
 

--- a/shopping_list/src/main/java/com/zizohanto/android/tobuy/shopping_list/presentation/views/shopping_list/ShoppingListsScreen.kt
+++ b/shopping_list/src/main/java/com/zizohanto/android/tobuy/shopping_list/presentation/views/shopping_list/ShoppingListsScreen.kt
@@ -56,10 +56,12 @@ import com.zizohanto.android.tobuy.shopping_list.presentation.views.EmptyStateVi
 
 @Composable
 fun ShoppingListsScreen(
+    shouldRefreshList: Boolean,
     listCLick: (String) -> Unit = {},
     viewModel: ShoppingListViewModel = hiltViewModel()
 ) {
     val state by viewModel.viewState.collectAsState(initial = ShoppingListViewState.Idle)
+    if (shouldRefreshList) viewModel.loadShoppingLists()
     with(viewModel) {
         ShoppingListsContent(
             state,
@@ -73,7 +75,7 @@ fun ShoppingListsScreen(
                 onCreateShoppingList()
             },
             retry = {
-                onRetry()
+                loadShoppingLists()
             }
         )
     }

--- a/shopping_list/src/main/java/com/zizohanto/android/tobuy/shopping_list/ui/ShoppingListApp.kt
+++ b/shopping_list/src/main/java/com/zizohanto/android/tobuy/shopping_list/ui/ShoppingListApp.kt
@@ -19,8 +19,10 @@ fun ShoppingListNavHost(
     navController: NavHostController
 ) {
     NavHost(navController = navController, startDestination = Screen.ShoppingList.route) {
-        composable(route = Screen.ShoppingList.route) {
+        composable(route = Screen.ShoppingList.route) { entry ->
+            val shouldRefresh = entry.savedStateHandle.remove<Boolean>(IS_FROM_BACK_PRESS) ?: false
             ShoppingListsScreen(
+                shouldRefreshList = shouldRefresh,
                 listCLick = { shoppingListId ->
                     navController.navigate(Screen.Products.createRoute(shoppingListId))
                 }
@@ -28,8 +30,15 @@ fun ShoppingListNavHost(
         }
         composable(route = Screen.Products.route, arguments = Screen.Products.navArguments) {
             ProductsScreen(
-                onBackPressed = { navController.navigateUp() }
+                onBackPressed = {
+                    with(navController) {
+                        previousBackStackEntry?.savedStateHandle?.set(IS_FROM_BACK_PRESS, true)
+                        navigateUp()
+                    }
+                }
             )
         }
     }
 }
+
+private const val IS_FROM_BACK_PRESS = "is_from_back_press"


### PR DESCRIPTION
This PR fixes the issue where the shopping lists aren't updated after returning from the products screen.